### PR TITLE
change getting started btn link

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,7 +71,7 @@
         <br>
         <button class="tag text-uppercase">Developer Preview</button>
         <br>
-        <a class="btn btn-primary" role="button" href="http://loopback.io/doc/en/lb4/Getting-started.html">Get Started with LoopBack 4</a>
+        <a class="btn btn-primary" role="button" href="getting-started.html">Get Started with LoopBack 4</a>
     </div>
 
     <!-- Feature section -->


### PR DESCRIPTION
Now that we have a Getting Started page, the Getting Started button in the "blue banner" should point to that page.

Signed-off-by: Diana Lau <dhmlau@ca.ibm.com>