### PR TITLE
git clone, not npm clone

### DIFF
--- a/getting-started-oasgraph.html
+++ b/getting-started-oasgraph.html
@@ -103,7 +103,7 @@
           </div>
           <div class="col-md-6">
             <pre class="code-snippet">
-<code-blue>$</code-blue> npm clone git@github.com:strongloop/oasgraph.git
+<code-blue>$</code-blue> git clone git@github.com:strongloop/oasgraph.git
 <code-blue>$</code-blue> cd oasgraph
 <code-blue>$</code-blue> npm link
             </pre>


### PR DESCRIPTION
Alter doc to use `git clone` rather than non-existent `npm clone`.