### PR TITLE
Change LB4 release status

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,7 +63,7 @@
 
     <!--Header alert -->
     <div class="header-alert">
-        <p class="centered-regular">LoopBack 4 has reached GA (General Availability)</p>
+        <p class="centered-regular">LoopBack 4 GA (General Availability) has been released in October 2018, read more in <a href="http://strongloop.com/strongblog/loopback-4-ga">the announcement post</a></p>
     </div>
     <!-- Header -->
     <div class="masthead">

--- a/index.html
+++ b/index.html
@@ -63,7 +63,7 @@
 
     <!--Header alert -->
     <div class="header-alert">
-        <p class="centered-regular">LoopBack 4 is currently available as Developer Preview #3.</p>
+        <p class="centered-regular">LoopBack 4 has reached GA (General Availability)</p>
     </div>
     <!-- Header -->
     <div class="masthead">
@@ -72,7 +72,6 @@
         <h5>LoopBack 4 is the next step in the evolution of LoopBack.</h5>
         <img class="main-logo" src="img/global/loopback-mark-frame-white.svg"></img>
         <br>
-        <button class="tag text-uppercase">Developer Preview</button>
         <br>
         <a class="btn btn-primary" role="button" href="getting-started.html">Get Started with LoopBack 4</a>
     </div>


### PR DESCRIPTION
**Do not merge until we're ready for GA**

Change the status to GA at the top of the landing page.
I am between removing that header alert completely or just change the wording.  Please let me know what you think! 