### PR TITLE
Updated docs for new OASGraph UX, see #43

### DIFF
--- a/getting-started-oasgraph.html
+++ b/getting-started-oasgraph.html
@@ -102,13 +102,11 @@
           </div>
           <div class="col-md-6">
             <h3 class="feature-heading">Install OASGraph</h3>
-            <p class="p large step">OASGraph can be used either as a library, or via its Command Line Interface (CLI). To install OASGraph, clone the repository and link the library (for the CLI commands to work) using the indicated steps.</p>
+            <p class="p large step">OASGraph can be used either as a library, or via its Command Line Interface (CLI) to quickly get started. To install the OASGraph CLI, simply run the indicated command.</p>
           </div>
           <div class="col-md-6">
             <pre class="code-snippet">
-<code-blue>$</code-blue> git clone git@github.com:strongloop/oasgraph.git
-<code-blue>$</code-blue> cd oasgraph
-<code-blue>$</code-blue> npm link
+<code-blue>$</code-blue> npm i -g oasgraph-cli
             </pre>
           </div>
         </div>


### PR DESCRIPTION
This update to the OASGraph documentation reflects our changes to decouple OASGraph core from OASGraph CLI (see https://github.com/strongloop/oasgraph/issues/59).

As of now, users can simply run `npm i -g oasgraph-cli` to get started with OASGraph.