### PR TITLE
Fix broken link for tutorials

### DIFF
--- a/contribute.html
+++ b/contribute.html
@@ -194,7 +194,7 @@
                         <a href="http://loopback.io/doc/en/lb4/Getting-started.html">Getting Started</a>
                     </p>
                     <p class="regular">
-                        <a href="http://loopback.io/doc/en/lb4/Examples-and-tutorials.html">Tutorials</a>
+                        <a href="http://loopback.io/doc/en/lb4/Tutorials.html">Tutorials</a>
                     </p>
                 </div>
                 <div class="col-md-3">

--- a/getting-started-oasgraph.html
+++ b/getting-started-oasgraph.html
@@ -192,7 +192,7 @@
                         <a href="http://loopback.io/doc/en/lb4/Getting-started.html">Getting Started</a>
                     </p>
                     <p class="regular">
-                        <a href="http://loopback.io/doc/en/lb4/Examples-and-tutorials.html">Tutorials</a>
+                        <a href="http://loopback.io/doc/en/lb4/Tutorials.html">Tutorials</a>
                     </p>
                 </div>
                 <div class="col-md-3">

--- a/getting-started.html
+++ b/getting-started.html
@@ -290,7 +290,7 @@ Controller Hello was now created in src/controllers/
                         <a href="http://loopback.io/doc/en/lb4/Getting-started.html">Getting Started</a>
                     </p>
                     <p class="regular">
-                        <a href="http://loopback.io/doc/en/lb4/Examples-and-tutorials.html">Tutorials</a>
+                        <a href="http://loopback.io/doc/en/lb4/Tutorials.html">Tutorials</a>
                     </p>
                 </div>
                 <div class="col-md-3">

--- a/index.html
+++ b/index.html
@@ -203,7 +203,7 @@
                         <a href="http://loopback.io/doc/en/lb4/Getting-started.html">Getting Started</a>
                     </p>
                     <p class="regular">
-                        <a href="http://loopback.io/doc/en/lb4/Examples-and-tutorials.html">Tutorials</a>
+                        <a href="http://loopback.io/doc/en/lb4/Tutorials.html">Tutorials</a>
                     </p>
                 </div>
                 <div class="col-md-3">

--- a/oasgraph.html
+++ b/oasgraph.html
@@ -208,7 +208,7 @@
                         <a href="http://loopback.io/doc/en/lb4/Getting-started.html">Getting Started</a>
                     </p>
                     <p class="regular">
-                        <a href="http://loopback.io/doc/en/lb4/Examples-and-tutorials.html">Tutorials</a>
+                        <a href="http://loopback.io/doc/en/lb4/Tutorials.html">Tutorials</a>
                     </p>
                 </div>
                 <div class="col-md-3">

--- a/resources.html
+++ b/resources.html
@@ -112,7 +112,7 @@
                 </div>
     
                 <div class="col-sm-12 col-md-6">
-                    <a class="card-2" href="https://loopback.io/doc/en/lb4/Examples-and-tutorials.html" target="_blank">
+                    <a class="card-2" href="https://loopback.io/doc/en/lb4/Tutorials.html" target="_blank">
                         <div class="row">
                             <div class="col-sm-3">
                                 <img class="icon" src="img/resources/application-icon-1x.png" alt="Application Icon"/>
@@ -343,7 +343,7 @@
                         <a href="http://loopback.io/doc/en/lb4/Getting-started.html">Getting Started</a>
                     </p>
                     <p class="regular">
-                        <a href="http://loopback.io/doc/en/lb4/Examples-and-tutorials.html">Tutorials</a>
+                        <a href="http://loopback.io/doc/en/lb4/Tutorials.html">Tutorials</a>
                     </p>
                 </div>
                 <div class="col-md-3">


### PR DESCRIPTION
Fixes https://github.com/strongloop/loopback-next/issues/2534

When we're splitting the `Tutorials and Examples` into 2, we should update the links in the v4.loopback.io. 