### PR TITLE
update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 
 # v4.loopback.io
 
+**Note: This repo is deprecated and will be archived. Please go to [loopback.io](https://loopback.io) for the latest web site content.**
+
 LoopBack web site dedicated to version 4: [http://v4.loopback.io](http://v4.loopback.io).
 
 This repository is provided under the [MIT License](LICENSE).


### PR DESCRIPTION
The web site v4.loopback.io is no longer in use, so as this repo. 

Before archiving this repo, I'd like to update the README to mention the current status.

I'd like to get the redirect working before archiving the repo. @nabdelgadir found this instruction: https://gist.github.com/domenic/1f286d415559b56d725bee51a62c24a7, and will try it soon.